### PR TITLE
http to https, version 0.2.0 -> 0.2.1

### DIFF
--- a/lib/spectrum_hash/splash.rb
+++ b/lib/spectrum_hash/splash.rb
@@ -7,7 +7,7 @@ module SpectrumHash
   class Splash
     attr_reader :spectrum, :spectrum_type, :api_uri, :response, :splash
 
-    DEFAULT_SPLASH_API_URI = 'http://splash.fiehnlab.ucdavis.edu/splash/it'
+    DEFAULT_SPLASH_API_URI = 'https://splash.fiehnlab.ucdavis.edu/splash/it'
 
     DEFAULT_SPECTRUM_TYPE = :ms
     SPECTRUM_TYPES = {ms: 1, nmr: 2, uv_vis: 3, ir: 4, raman: 5}.freeze

--- a/lib/spectrum_hash/version.rb
+++ b/lib/spectrum_hash/version.rb
@@ -1,3 +1,3 @@
 module SpectrumHash
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Url for access has changed from 'http://splash.fiehnlab.ucdavis.edu/splash/it' to 'https://splash.fiehnlab.ucdavis.edu/splash/it'.